### PR TITLE
Bee Joker True Debuff

### DIFF
--- a/Bee.lua
+++ b/Bee.lua
@@ -17,11 +17,11 @@ function GetBees()
 	local beeCount = 0
 	for i = 1, #G.jokers.cards do
 		if 
-			G.jokers.cards[i]:bonus_bees() > 0
+			G.jokers.cards[i]:bonus_bees() > 0 and not G.jokers.cards[i].debuff
 		then
 			beeCount = beeCount + G.jokers.cards[i]:bonus_bees()
 		elseif
-			G.jokers.cards[i]:is_bee()
+			G.jokers.cards[i]:is_bee() and not G.jokers.cards[i].debuff
 		then
 			beeCount = beeCount + 1
 		end


### PR DESCRIPTION
Changed the GetBees() function so that when bee jokers are debuffed, they stop counting as bee jokers for bee count. In the future we may want to consider rewriting this to also check playing cards and boosters as through the sticker deck they can also have them. We may want to wait on that till after playtesting.